### PR TITLE
feat: HTML tag, component and directive completion in template

### DIFF
--- a/src/features/attrNameCase.ts
+++ b/src/features/attrNameCase.ts
@@ -1,0 +1,25 @@
+import { ExtensionContext, workspace } from 'coc.nvim';
+import { LanguageClient } from 'vscode-languageclient/node';
+import * as shared from '@volar/shared';
+
+export async function activate(context: ExtensionContext, languageClient: LanguageClient) {
+  await languageClient.onReady();
+
+  while ((await languageClient.sendRequest(shared.PingRequest.type)) !== 'pong') {
+    await shared.sleep(100);
+  }
+
+  languageClient.onRequest(shared.GetClientAttrNameCaseRequest.type, async (handler) => {
+    // @ts-ignore
+    const attrCase = attrCases.get(handler.uri);
+    return attrCase ?? 'kebabCase';
+  });
+
+  const attrCases = new shared.UriMap<'kebabCase' | 'pascalCase'>();
+
+  context.subscriptions.push(
+    workspace.onDidCloseTextDocument((doc) => {
+      attrCases.delete(doc.uri.toString());
+    })
+  );
+}

--- a/src/features/tagNameCase.ts
+++ b/src/features/tagNameCase.ts
@@ -1,0 +1,34 @@
+import { ExtensionContext, workspace } from 'coc.nvim';
+import { LanguageClient } from 'vscode-languageclient/node';
+import * as shared from '@volar/shared';
+
+export async function activate(context: ExtensionContext, languageClient: LanguageClient) {
+  await languageClient.onReady();
+
+  while ((await languageClient.sendRequest(shared.PingRequest.type)) !== 'pong') {
+    await shared.sleep(100);
+  }
+
+  languageClient.onRequest(shared.GetClientTarNameCaseRequest.type, async (handler) => {
+    // @ts-ignore
+    let tagCase = tagCases.get(handler.uri);
+    if (tagCase === 'unsure') {
+      const templateCases = await languageClient.sendRequest(shared.GetServerNameCasesRequest.type, handler);
+      if (templateCases) {
+        // @ts-ignore
+        tagCase = templateCases.tag;
+        // @ts-ignore
+        tagCases.set(handler.uri, tagCase);
+      }
+    }
+    return !tagCase || tagCase === 'unsure' ? 'both' : tagCase;
+  });
+
+  const tagCases = new shared.UriMap<'both' | 'kebabCase' | 'pascalCase' | 'unsure'>();
+
+  context.subscriptions.push(
+    workspace.onDidCloseTextDocument((doc) => {
+      tagCases.delete(doc.uri.toString());
+    })
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import type * as shared from '@volar/shared';
 ////////////
 
 import * as activeSelection from './features/activeSelection';
-// import * as attrNameCase from './features/attrNameCase';
+import * as attrNameCase from './features/attrNameCase';
 /** MEMO: Cannot be ported due to use of webview */
 // import * as callGraph from './features/callGraph';
 import * as createWorkspaceSnippets from './features/createWorkspaceSnippets';
@@ -36,7 +36,7 @@ import * as restart from './features/restart';
 import * as showReferences from './features/showReferences';
 // import * as splitEditors from './features/splitEditors';
 // import * as tagClosing from './features/tagClosing';
-// import * as tagNameCase from './features/tagNameCase';
+import * as tagNameCase from './features/tagNameCase';
 // import * as tsPlugin from './features/tsPlugin';
 // import * as tsVersion from './features/tsVersion';
 import * as verifyAll from './features/verifyAll';
@@ -72,8 +72,10 @@ export async function activate(context: ExtensionContext): Promise<void> {
   // preview.activate(context);
   // @ts-ignore
   createWorkspaceSnippets.activate(context);
-  // tagNameCase.activate(context, apiClient);
-  // attrNameCase.activate(context, apiClient);
+  // @ts-ignore
+  tagNameCase.activate(context, apiClient);
+  // @ts-ignore
+  attrNameCase.activate(context, apiClient);
   /** MEMO: Cannot be ported due to use of webview */
   // callGraph.activate(context, apiClient);
   // @ts-ignore


### PR DESCRIPTION
"HTML tags", "component names", and "directives" can now be complettion in the `<template>`.

I've ported the **minimum feature** for each auto completion to work.